### PR TITLE
Save mapping and init from mapping

### DIFF
--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -1,6 +1,7 @@
 """GRiTS: Coarse-graining tools."""
 __all__ = ["CG_Compound", "Bead"]
 
+import json
 import os
 import tempfile
 from collections import defaultdict
@@ -24,7 +25,7 @@ class CG_Compound(Compound):
     ----------
     compound : mbuild.Compound
         Fine-grain structure to be coarse-grained
-    beads : dict
+    beads : dict, default None
         Dictionary with keys containing desired bead name and values containing
         SMARTS string specification of that bead. For example::
 
@@ -32,6 +33,15 @@ class CG_Compound(Compound):
 
         would map a ``"_B"`` bead to any thiophene moiety (``"c1sccc1"``) found
         in the compound and an ``"_S"`` bead to a propyl moiety (``"CCC"``).
+        User must provide only one of beads or mapping.
+    mapping : dict or path, default None
+        Either a dictionary or path to a json file of a dictionary. Dictionary
+        keys contain desired bead name and SMARTS string specification of that
+        bead and values containing list of tuples of atom indices::
+
+            mapping = {('_B', 'c1sccc1'): [(0, 4, 3, 2, 1), ...]}
+
+        User must provide only one of beads or mapping.
 
     Attributes
     ----------
@@ -56,16 +66,26 @@ class CG_Compound(Compound):
             [('_B-_S', (3, 0)), ...]
     """
 
-    def __init__(self, compound, beads):
-        super(CG_Compound, self).__init__()
+    def __init__(self, compound, beads=None, mapping=None, **kwargs):
+        super(CG_Compound, self).__init__(**kwargs)
+        if (beads is None) == (mapping is None):
+            raise ValueError(
+                "Please provide only one of either beads or mapping."
+            )
         self.atomistic = compound
         self.anchors = None
         self.bond_map = None
 
-        mol = compound.to_pybel()
-        mol.OBMol.PerceiveBondOrders()
+        if beads is not None:
+            mol = compound.to_pybel()
+            mol.OBMol.PerceiveBondOrders()
 
-        self._set_mapping(beads, mol)
+            self._set_mapping(beads, mol)
+        elif mapping is not None:
+            if not isinstance(mapping, dict):
+                with open(mapping, "r") as f:
+                    mapping = json.load(f)
+            self.mapping = mapping
         self._cg_particles()
         self._cg_bonds()
 
@@ -96,14 +116,14 @@ class CG_Compound(Compound):
             # add bead regardless of whether it was seen
             if has_number(smarts):
                 seen.update(group)
-                mapping[(name, smarts)].append(group)
+                mapping[f"{name}...{smarts}"].append(group)
             # alkyl chains should be exclusive
             else:
                 if has_common_member(seen, group):
                     pass
                 else:
                     seen.update(group)
-                    mapping[(name, smarts)].append(group)
+                    mapping[f"{name}...{smarts}"].append(group)
 
         n_atoms = mol.OBMol.NumHvyAtoms()
         if n_atoms != len(seen):
@@ -113,7 +133,8 @@ class CG_Compound(Compound):
 
     def _cg_particles(self):
         """Set the beads in the coarse-structure."""
-        for (name, smarts), inds in self.mapping.items():
+        for key, inds in self.mapping.items():
+            name, smarts = key.split("...")
             for group in inds:
                 bead_xyz = self.atomistic.xyz[group, :]
                 avg_xyz = np.mean(bead_xyz, axis=0)
@@ -124,8 +145,8 @@ class CG_Compound(Compound):
         """Set the bonds in the coarse structure."""
         bonds = get_bonds(self.atomistic)
         bead_inds = [
-            (name, group)
-            for (name, _), inds in self.mapping.items()
+            (key.split("...")[0], group)
+            for key, inds in self.mapping.items()
             for group in inds
         ]
         anchors = defaultdict(set)
@@ -163,6 +184,14 @@ class CG_Compound(Compound):
 
         self.anchors = anchors
         self.bond_map = bond_map
+
+    def _save_mapping(self, filename=None):
+        if filename is None:
+            filename = f"{self.name}_mapping.json"
+        with open(filename, "w") as f:
+            json.dump(self.mapping, f)
+        print(f"Mapping saved to {filename}")
+        return filename
 
     def visualize(
         self, show_ports=False, color_scheme={}, show_atomistic=False, scale=1.0

--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -39,7 +39,7 @@ class CG_Compound(Compound):
         keys contain desired bead name and SMARTS string specification of that
         bead and values containing list of tuples of atom indices::
 
-            mapping = {('_B', 'c1sccc1'): [(0, 4, 3, 2, 1), ...]}
+            mapping = {"_B...c1sccc1"): [(0, 4, 3, 2, 1), ...]}
 
         User must provide only one of beads or mapping.
 
@@ -49,10 +49,10 @@ class CG_Compound(Compound):
         The atomistic structure.
     mapping : dict
         A mapping from atomistic to coarse-grain structure. Dictionary keys are
-        a tuple of bead name and smart string, and the values are a list of
-        tuples of fine-grain particle indices for each bead instance::
+        the bead name and SMARTS string (separated by "..."), and the values are
+        a list of tuples of fine-grain particle indices for each bead instance::
 
-            {('_B', 'c1sccc1'): [(0, 4, 3, 2, 1), ...], ...}
+            {"_B...c1sccc1"): [(0, 4, 3, 2, 1), ...], ...}
 
     anchors : dict
         A mapping of the anchor particle indices in each bead. Dictionary keys
@@ -185,7 +185,21 @@ class CG_Compound(Compound):
         self.anchors = anchors
         self.bond_map = bond_map
 
-    def _save_mapping(self, filename=None):
+    def save_mapping(self, filename=None):
+        """Save the mapping operator to a json file.
+
+        Parameters
+        ----------
+        filename : str, default None
+            Filename where the mapping operator will be saved in json format.
+            If None is provided, the filename will be CG_Compound.name +
+            "_mapping.json".
+
+        Returns
+        -------
+        str
+            Path to saved mapping
+        """
         if filename is None:
             filename = f"{self.name}_mapping.json"
         with open(filename, "w") as f:

--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -192,9 +192,9 @@ class CG_Compound(Compound):
                             bond_map.insert(0, bondinfo)
 
                     self.add_bond([self[i], self[j + i + 1]])
-
-        self.anchors = anchors
-        self.bond_map = bond_map
+        if anchors and bond_map:
+            self.anchors = anchors
+            self.bond_map = bond_map
 
     def save_mapping(self, filename=None):
         """Save the mapping operator to a json file.

--- a/grits/finegrain.py
+++ b/grits/finegrain.py
@@ -36,8 +36,9 @@ def backmap(cg_compound):
             b = load(smiles, smiles=True)
             b.translate_to(bead.pos)
             anchors[i] = dict()
-            for index in cg_compound.anchors[bead.name]:
-                anchors[i][index] = b[index]
+            if cg_compound.anchors is not None:
+                for index in cg_compound.anchors[bead.name]:
+                    anchors[i][index] = b[index]
             fine_grained.add(b, str(i))
         return fine_grained, anchors
 

--- a/grits/tests/base_test.py
+++ b/grits/tests/base_test.py
@@ -9,6 +9,11 @@ test_dir = path.dirname(__file__)
 
 
 class BaseTest:
+    def mapping(self, cg_comp, tmpdir):
+        filename = tmpdir.mkdir("sub").join("mapping.txt")
+        cg_comp.save_mapping(filename)
+        return filename
+
     @pytest.fixture
     def p3ht(self):
         p3ht = mb.load(path.join(test_dir, "assets/P3HT_16.mol2"))
@@ -20,11 +25,21 @@ class BaseTest:
         return methane
 
     @pytest.fixture
-    def cg_methane(self, methane):
-        cg_beads = {"_A": "C"}
+    def alkane(self):
+        chain = mb.load("CCC" * 4, smiles=True)
+        return chain
 
-        cg_methane = CG_Compound(methane, cg_beads)
-        return cg_methane
+    @pytest.fixture
+    def p3ht_mapping(self, p3ht):
+        return mapping(p3ht)
+
+    @pytest.fixture
+    def methane_mapping(self, methane):
+        return mapping(methane)
+
+    @pytest.fixture
+    def alkane_mapping(self, alkane):
+        return mapping(alkane)
 
     @pytest.fixture
     def cg_p3ht(self, p3ht):
@@ -34,9 +49,11 @@ class BaseTest:
         return cg_p3ht
 
     @pytest.fixture
-    def alkane(self):
-        chain = mb.load("CCC" * 4, smiles=True)
-        return chain
+    def cg_methane(self, methane):
+        cg_beads = {"_A": "C"}
+
+        cg_methane = CG_Compound(methane, cg_beads)
+        return cg_methane
 
     @pytest.fixture
     def cg_alkane(self, alkane):

--- a/grits/tests/base_test.py
+++ b/grits/tests/base_test.py
@@ -9,11 +9,6 @@ test_dir = path.dirname(__file__)
 
 
 class BaseTest:
-    def mapping(self, cg_comp, tmpdir):
-        filename = tmpdir.mkdir("sub").join("mapping.txt")
-        cg_comp.save_mapping(filename)
-        return filename
-
     @pytest.fixture
     def p3ht(self):
         p3ht = mb.load(path.join(test_dir, "assets/P3HT_16.mol2"))
@@ -30,16 +25,22 @@ class BaseTest:
         return chain
 
     @pytest.fixture
-    def p3ht_mapping(self, p3ht):
-        return mapping(p3ht)
+    def p3ht_mapping(self, cg_p3ht, tmpdir):
+        filename = tmpdir.mkdir("sub").join("p3htmapping.json")
+        cg_p3ht.save_mapping(filename)
+        return filename
 
     @pytest.fixture
-    def methane_mapping(self, methane):
-        return mapping(methane)
+    def methane_mapping(self, cg_methane, tmpdir):
+        filename = tmpdir.mkdir("sub").join("methanemapping.json")
+        cg_methane.save_mapping(filename)
+        return filename
 
     @pytest.fixture
-    def alkane_mapping(self, alkane):
-        return mapping(alkane)
+    def alkane_mapping(self, cg_alkane):
+        filename = tmpdir.mkdir("sub").join("alkanemapping.json")
+        cg_alkane.save_mapping(filename)
+        return filename
 
     @pytest.fixture
     def cg_p3ht(self, p3ht):

--- a/grits/tests/test_coarsegrain.py
+++ b/grits/tests/test_coarsegrain.py
@@ -5,7 +5,7 @@ from grits import CG_Compound
 
 
 class Test_CGCompound(BaseTest):
-    def test_init_methane(self, methane):
+    def test_initmethane(self, methane):
         cg_beads = {"_A": "C"}
 
         cg_methane = CG_Compound(methane, cg_beads)
@@ -17,7 +17,7 @@ class Test_CGCompound(BaseTest):
         assert "_A" in types
         assert len(types) == 1
 
-    def test_init_p3ht(self, p3ht):
+    def test_initp3ht(self, p3ht):
         cg_beads = {"_B": "c1sccc1", "_S": "CCC"}
 
         cg_p3ht = CG_Compound(p3ht, cg_beads)
@@ -29,6 +29,27 @@ class Test_CGCompound(BaseTest):
         assert "_B" in types
         assert "_S" in types
         assert len(types) == 2
+
+    def test_initmapp3ht(self, p3ht, p3ht_mapping):
+        cg_p3ht = CG_Compound(p3ht, mapping=p3ht_mapping)
+
+        assert cg_p3ht.n_particles == 48
+        assert isinstance(cg_p3ht, CG_Compound)
+
+        types = set([i.name for i in cg_p3ht.particles()])
+        assert "_B" in types
+        assert "_S" in types
+        assert len(types) == 2
+
+    def test_initmapmethane(self, methane, methane_mapping):
+        cg_methane = CG_Compound(methane, mapping=methane_mapping)
+
+        assert cg_methane.n_particles == 1
+        assert isinstance(cg_methane, CG_Compound)
+
+        types = set([i.name for i in cg_methane.particles()])
+        assert "_A" in types
+        assert len(types) == 1
 
     def test_notfoundsmarts(self, methane):
         cg_beads = {"_A": "CCC"}

--- a/grits/tests/test_coarsegrain.py
+++ b/grits/tests/test_coarsegrain.py
@@ -82,6 +82,9 @@ class Test_CGCompound(BaseTest):
         with pytest.raises(ValueError):
             CG_Compound(p3ht)
 
+    def test_savemapping(self, cg_methane):
+        assert cg_methane.save_mapping() == "CG_Compound_mapping.json"
+
     def test_reprnoerror(self, cg_methane, cg_p3ht):
         str(cg_p3ht)
         str(cg_methane)

--- a/grits/tests/test_coarsegrain.py
+++ b/grits/tests/test_coarsegrain.py
@@ -30,6 +30,19 @@ class Test_CGCompound(BaseTest):
         assert "_S" in types
         assert len(types) == 2
 
+    def test_initp3htoverlap(self, p3ht):
+        cg_beads = {"_B": "c1sccc1", "_S": "CCC"}
+
+        cg_p3ht = CG_Compound(p3ht, cg_beads, allow_overlap=True)
+
+        assert cg_p3ht.n_particles == 48
+        assert isinstance(cg_p3ht, CG_Compound)
+
+        types = set([i.name for i in cg_p3ht.particles()])
+        assert "_B" in types
+        assert "_S" in types
+        assert len(types) == 2
+
     def test_initmapp3ht(self, p3ht, p3ht_mapping):
         cg_p3ht = CG_Compound(p3ht, mapping=p3ht_mapping)
 

--- a/grits/tests/test_coarsegrain.py
+++ b/grits/tests/test_coarsegrain.py
@@ -42,6 +42,12 @@ class Test_CGCompound(BaseTest):
         with pytest.warns(UserWarning):
             CG_Compound(p3ht, cg_beads)
 
+    def test_badinit(self, p3ht):
+        with pytest.raises(ValueError):
+            CG_Compound(p3ht, beads="heck", mapping="this")
+        with pytest.raises(ValueError):
+            CG_Compound(p3ht)
+
     def test_reprnoerror(self, cg_methane, cg_p3ht):
         str(cg_p3ht)
         str(cg_methane)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ AUTHOR = "Jenny Fothergill"
 REQUIRES_PYTHON = ">=3.7.0"
 
 # What packages are required for this module to be executed?
-REQUIRED = ["mbuild", "numpy", "openbabel", "rdkit"]
+REQUIRED = ["mbuild", "numpy"]
 
 # The rest you shouldn't have to touch too much :)
 # ------------------------------------------------


### PR DESCRIPTION
## Summary:
- add save_mapping function (this required changing the mapping keys to be json serializable (not tuple))
- allow a CG_Compound to be initialized from bead specification or a mapping 
- add allow_overlap to decide if ring structures share atoms

- [x] add unit tests

fixes #11 fixes #12 