### PR TITLE
CGing approach using Freud clusters

### DIFF
--- a/grits/cg_gsd.py
+++ b/grits/cg_gsd.py
@@ -1,0 +1,277 @@
+from cmeutils import gsd_utils
+from cmeutils.gsd_utils import snap_molecule_cluster
+import freud
+import numpy as np
+
+class System:
+    """
+    """
+    def __init__(self,
+            atoms_per_monomer,
+            gsd_file=None,
+            snap=None,
+            gsd_frame=-1):
+        self.atoms_per_monomer = atoms_per_monomer
+        self.snap = gsd_utils._validate_inputs(gsd_file, snap, gsd_frame)
+        self.clusters = snap_molecule_cluster(snap=self.snap)
+        self.molecule_ids = set(self.clusters)
+        self.n_molecules = len(self.molecule_ids)
+        self.n_atoms = len(self.clusters)
+        self.n_monomers = int(self.n_atoms / self.atoms_per_monomer)
+        self.molecules = [Molecule(self, i) for i in self.molecule_ids] 
+        self.box = gsd_utils.snap_box(gsd_file, snap, gsd_frame)
+        assert len(self.molecules) == self.n_molecules
+
+    def monomers(self):
+        """Generate all of the monomers from each molecule
+        in System.molecules.
+
+        Yields:
+        -------
+        polymers.Monomer
+     
+        """
+        for molecule in self.molecules:
+            for monomer in molecule.monomers:
+                yield monomer
+
+    def segments(self):
+        """Generate all of the segments from each molecule
+        in System.
+
+        Yields:
+        -------
+        polymers.Segment
+
+        """
+        for molecule in self.molecules:
+            for segment in molecule.segments:
+                yield segment
+
+    def components(self):
+        """Generate all of the components from each molecule in System.
+
+        Yields:
+        -------
+        polymers.Component
+
+        """
+        for monomer in self.monomers():
+            for component in monomer.components:
+                yield component
+
+
+class Structure:
+    """Base class for the Molecule(), Segment(), and Monomer() classes.
+
+    Parameters:
+    -----------
+    system : 'cmeutils.polymers.System', required
+        The system object initially created from the input .gsd file.
+    atom_indices : np.ndarray(n, 3), optional, default=None
+        The atom indices in the system that belong to this specific structure.
+    molecule_id : int, optional, default=None
+        The ID number of the specific molecule from system.molecule_ids.
+
+    Attributes:
+    -----------
+    system : 'cmeutils.polymers.System'
+        The system that this structure belong to. Contains needed information
+        about the box, and gsd snapshot which are used elsewhere.
+    atom_indices : np.ndarray(n_atoms, 3)
+        The atom indices in the system that belong to this specific structure
+    n_atoms : int
+        The number of atoms that belong to this specific structure
+    atom_positions : np.narray(n_atoms, 3)
+        The x, y, z coordinates of the atoms belonging to this structure.
+        The positions are wrapped inside the system's box.
+    center_of_mass : np.1darray(1, 3)
+        The x, y, z coordinates of the structure's center of mass.
+
+    """
+    def __init__(self,
+            system,
+            atom_indices=None,
+            name=None,
+            parent=None,
+            molecule_id=None
+            ):
+        self.system = system
+        self.name = name
+        self.parent = parent
+        if molecule_id != None:
+            self.atom_indices = np.where(self.system.clusters == molecule_id)[0]
+            self.molecule_id = molecule_id
+        else:
+            self.atom_indices = atom_indices
+        self.n_atoms = len(self.atom_indices)
+
+    def generate_monomers(self):
+        if isinstance(self, Monomer):
+            return self
+        structure_length = int(self.n_atoms / self.system.atoms_per_monomer)
+        monomer_indices = np.array_split(self.atom_indices, structure_length)
+        assert len(monomer_indices) == structure_length
+        return [Monomer(self, i) for i in monomer_indices]
+
+    @property
+    def atom_positions(self):
+        """The wrapped coordinates of every particle in the structure
+        as they exist in the periodic box.
+
+        Returns:
+        --------
+        numpy.ndarray, shape=(n, 3), dtype=float
+
+        """
+        return self.system.snap.particles.position[self.atom_indices]
+
+    @property
+    def center(self):
+        """The (x,y,z) position of the center of the structure accounting
+        for the periodic boundaries in the system.
+        
+        Returns:
+        --------
+        numpy.ndarray, shape=(3,), dtype=float
+
+        """
+        freud_box = freud.Box(
+                Lx = self.system.box[0],
+                Ly = self.system.box[1],
+                Lz = self.system.box[2]
+                )
+        return freud_box.center_of_mass(self.atom_positions)
+
+    @property 
+    def unwrapped_atom_positions(self):
+        """The unwrapped coordiantes of every particle in the structure.
+        The positions are unwrapped using the images for each particle
+        stored in the hoomd snapshot.
+
+        Returns:
+        --------
+        numpy.ndarray, shape=(n, 3), dtype=float
+
+        """
+        images = self.system.snap.particles.image[self.atom_indices]
+        return self.atom_positions + (images * self.system.box[:3]) 
+
+    @property
+    def unwrapped_center(self):
+        """The (x,y,z) position of the center using the structure's
+        unwrapped coordiantes.
+
+        Returns:
+        --------
+        numpy.ndarray, shape=(3,), dtype=float
+
+        """
+        x_mean = np.mean(self.unwrapped_atom_positions[:,0])
+        y_mean = np.mean(self.unwrapped_atom_positions[:,1])
+        z_mean = np.mean(self.unwrapped_atom_positions[:,2])
+        return np.array([x_mean, y_mean, z_mean])
+
+class Molecule(Structure):
+    """
+    """
+    def __init__(self, system, molecule_id):
+        super(Molecule, self).__init__(
+                system=system,
+                molecule_id=molecule_id
+                )
+        self.monomers = self.generate_monomers() 
+        self.n_monomers = len(self.monomers)
+        self.segments = None
+        self.n_segments = None
+        self.sequence = None
+
+    def assign_types(self, sequence):
+        n = self.n_monomers // len(sequence)
+        monomer_sequence = sequence * n
+        monomer_sequence += sequence[:(self.n_monomers - len(monomer_sequence))]
+        for i, name in enumerate(list(monomer_sequence)):
+            self.monomers[i].name = name
+
+    def generate_segments(self, monomers_per_segment):
+        """
+        Creates a `Segment` that contains a subset of it's `Molecule` atoms.
+
+        Segments are defined as containing a certain number of monomers.
+        For example, if you want 3 subsequent monomers contained in a single
+        Segment instance, use `monomers_per_segment = 3`.
+        The segments are accessible in the `Molecule.segments` attribute.
+
+        Parameters:
+        -----------
+        monomers_per_segment : int, required
+            Define the number of consecutive monomers that belong to
+            each segment.
+
+        """
+        segments_per_molecule = int(self.n_monomers / monomers_per_segment)
+        segment_indices = np.array_split(
+                self.atom_indices,
+                segments_per_molecule
+                )
+        self.segments = [Segment(self, i) for i in segment_indices]
+        self.n_segments = len(self.segments)
+    
+
+class Monomer(Structure):
+    """
+    """
+    def __init__(self, parent, atom_indices):
+        super(Monomer, self).__init__(
+                system=parent.system,
+                parent=parent,
+                atom_indices=atom_indices
+                )
+        self.components = None
+        assert self.n_atoms == self.system.atoms_per_monomer 
+        
+    def generate_components(self, index_mapping):
+        components = []
+        for name, indices in index_mapping.items():
+            if all([isinstance(i, list) for i in indices]):
+                for i in indices:
+                    component = Component(
+                            monomer=self,
+                            name=name,
+                            atom_indices = self.atom_indices[i]
+                            )
+                    components.append(component)
+            else:
+                component = Component(
+                        monomer=self,
+                        name=name,
+                        atom_indices = self.atom_indices[indices]
+                        )
+                components.append(component)
+        self.components = components
+
+
+class Segment(Structure):
+    """
+    """
+    def __init__(self, molecule, atom_indices):
+        super(Segment, self).__init__(
+                system=molecule.system,
+                atom_indices=atom_indices,
+                parent = molecule
+                )
+        self.monomers = self.generate_monomers()
+        assert len(self.monomers) ==  int(
+                self.n_atoms / self.system.atoms_per_monomer
+                )
+
+class Component(Structure):
+    def __init__(self, monomer, atom_indices, name):
+        super(Component, self).__init__(
+                system=monomer.system,
+                parent=monomer.parent,
+                atom_indices=atom_indices,
+                name=name
+                )
+        self.monomer = monomer
+        

--- a/grits/cg_gsd.py
+++ b/grits/cg_gsd.py
@@ -5,12 +5,13 @@ from cmeutils.gsd_utils import snap_molecule_cluster
 
 
 class System:
-    """
-    """
-    def __init__(self,
-            atoms_per_monomer,
-            snap=None,
-            ):
+    """ """
+
+    def __init__(
+        self,
+        atoms_per_monomer,
+        snap=None,
+    ):
         self.atoms_per_monomer = atoms_per_monomer
         self.snap = snap
         self.clusters = snap_molecule_cluster(snap=self.snap)
@@ -18,7 +19,7 @@ class System:
         self.n_molecules = len(self.molecule_ids)
         self.n_atoms = len(self.clusters)
         self.n_monomers = int(self.n_atoms / self.atoms_per_monomer)
-        self.molecules = [Molecule(self, i) for i in self.molecule_ids] 
+        self.molecules = [Molecule(self, i) for i in self.molecule_ids]
         self.box = snap.configuration.box
         assert len(self.molecules) == self.n_molecules
 
@@ -270,7 +271,8 @@ class Component(Structure):
             name=name,
         )
         self.monomer = monomer
-        
+
+
 def snap_molecule_cluster(snap=None):
     """Find molecule index for each particle.
 

--- a/grits/cg_gsd.py
+++ b/grits/cg_gsd.py
@@ -1,20 +1,13 @@
 import freud
 import numpy as np
-from cmeutils import gsd_utils
-from cmeutils.gsd_utils import snap_molecule_cluster
-
 
 class System:
     """ """
 
-    def __init__(
-        self,
-        atoms_per_monomer,
-        snap=None,
-    ):
+    def __init__(self, snap, atoms_per_monomer):
         self.atoms_per_monomer = atoms_per_monomer
         self.snap = snap
-        self.clusters = snap_molecule_cluster(snap=self.snap)
+        self.clusters = _snap_molecule_cluster(snap=self.snap)
         self.molecule_ids = set(self.clusters)
         self.n_molecules = len(self.molecule_ids)
         self.n_atoms = len(self.clusters)
@@ -175,8 +168,8 @@ class Structure:
 
 
 class Molecule(Structure):
-    """ """
-
+    """
+    """
     def __init__(self, system, molecule_id):
         super(Molecule, self).__init__(system=system, molecule_id=molecule_id)
         self.monomers = self.generate_monomers()
@@ -191,6 +184,7 @@ class Molecule(Structure):
         monomer_sequence += sequence[
             : (self.n_monomers - len(monomer_sequence))
         ]
+        self.sequence = monomer_sequence
         for i, name in enumerate(list(monomer_sequence)):
             self.monomers[i].name = name
 
@@ -219,8 +213,8 @@ class Molecule(Structure):
 
 
 class Monomer(Structure):
-    """ """
-
+    """
+    """
     def __init__(self, parent, atom_indices):
         super(Monomer, self).__init__(
             system=parent.system, parent=parent, atom_indices=atom_indices
@@ -250,11 +244,13 @@ class Monomer(Structure):
 
 
 class Segment(Structure):
-    """ """
-
+    """
+    """
     def __init__(self, molecule, atom_indices):
         super(Segment, self).__init__(
-            system=molecule.system, atom_indices=atom_indices, parent=molecule
+            system=molecule.system,
+            atom_indices=atom_indices,
+            parent=molecule
         )
         self.monomers = self.generate_monomers()
         assert len(self.monomers) == int(
@@ -273,7 +269,7 @@ class Component(Structure):
         self.monomer = monomer
 
 
-def snap_molecule_cluster(snap=None):
+def _snap_molecule_cluster(snap=None):
     """Find molecule index for each particle.
 
     Compute clusters of bonded molecules and return an array of the molecule

--- a/grits/writers.py
+++ b/grits/writers.py
@@ -28,7 +28,7 @@ def write_snapshot(beads):
                     pair *= 2
                 all_pairs.append(f"{pair[0]}-{pair[1]}")
                 pair_groups.append([idx, idx+1])
-        except:
+        except IndexError:
             pass
 
     types = list(set(all_types)) 

--- a/grits/writers.py
+++ b/grits/writers.py
@@ -26,7 +26,7 @@ def write_snapshot(beads):
                 if len(pair) == 1:
                     pair *= 2
                 all_pairs.append(f"{pair[0]}-{pair[1]}")
-                pair_groups.append([idx, idx+1])
+                pair_groups.append([idx, idx + 1])
                 pair_groups.append([idx, idx + 1])
         except IndexError:
             pass

--- a/grits/writers.py
+++ b/grits/writers.py
@@ -27,7 +27,6 @@ def write_snapshot(beads):
                     pair *= 2
                 all_pairs.append(f"{pair[0]}-{pair[1]}")
                 pair_groups.append([idx, idx + 1])
-                pair_groups.append([idx, idx + 1])
         except IndexError:
             pass
 

--- a/grits/writers.py
+++ b/grits/writers.py
@@ -22,9 +22,7 @@ def write_snapshot(beads):
         all_pos.append(bead.center)
         try:
             if bead.parent == beads[idx + 1].parent:
-                pair = list(set([bead.name, beads[idx + 1].name]))
-                if len(pair) == 1:
-                    pair *= 2
+                pair = sorted([bead.name, beads[idx+1].name)
                 all_pairs.append(f"{pair[0]}-{pair[1]}")
                 pair_groups.append([idx, idx + 1])
         except IndexError:
@@ -41,7 +39,7 @@ def write_snapshot(beads):
     s.bonds.M = 2
     s.angles.N = len(all_angles)
     s.particles.types = types
-    s.particles.typeids = np.array(type_ids)
+    s.particles.typeid = np.array(type_ids)
     s.particles.position = np.array(all_pos)
     s.bonds.types = pairs
     s.bonds.typeid = np.array(pair_ids)

--- a/grits/writers.py
+++ b/grits/writers.py
@@ -1,0 +1,52 @@
+import gsd
+import gsd.hoomd
+import numpy as np
+
+def write_snapshot(beads):
+    """
+    beads : iterable, required
+        An iterable of any of the structure classes in cg_gsd.py
+    """
+    all_types = []
+    all_pairs = []
+    pair_groups = []
+    all_angles = []
+    all_pos = []
+    box = None
+
+    for idx, bead in enumerate(beads):
+        if box is None:
+            box = bead.system.box
+        all_types.append(bead.name)
+        all_pos.append(bead.center)
+        try:
+            if bead.parent == beads[idx+1].parent:
+                pair = list(
+                    set([bead.name, beads[idx+1].name])
+                    )
+                if len(pair) == 1:
+                    pair *= 2
+                all_pairs.append(f"{pair[0]}-{pair[1]}")
+                pair_groups.append([idx, idx+1])
+        except:
+            pass
+
+    types = list(set(all_types)) 
+    pairs = list(set(all_pairs)) 
+    type_ids = [np.where(np.array(types)==i)[0][0] for i in all_types]
+    pair_ids = [np.where(np.array(pairs)==i)[0][0] for i in all_pairs]
+
+    s = gsd.hoomd.Snapshot()
+    s.particles.N = len(all_types)
+    s.bonds.N = len(all_pairs)
+    s.bonds.M = 2
+    s.angles.N = len(all_angles)
+    s.particles.types = types 
+    s.particles.typeids = np.array(type_ids) 
+    s.particles.position = np.array(all_pos)
+    s.bonds.types = pairs
+    s.bonds.typeid = np.array(pair_ids)
+    s.bonds.group = np.vstack(pair_groups)
+    s.configuration.box = box 
+    return s
+


### PR DESCRIPTION
This PR offers some CGing capabilities that utilizes the [Freud cluster module](https://freud.readthedocs.io/en/latest/modules/cluster.html#).

Some notes on how this is currently designed.
1. Objects for `Molecules` and `Monomers` are essentially created automatically. There is enough information in what's output by the cluster, and `atoms_per_monomer` to handle these.
2. The user can define different levels of beads using the `Segment` or `Component` classes. Segments are essentially a multiple of `Monomer` and components are index matching within a single monomer (Which can be achieved through SMARTS matching)
3. I added a `writer.gsd` file that has a gsd writer that works specifically with these data structures.

Here is an example of how an atomistic gsd could be loaded, CG'd at the level of monomers and a new GSD created with the monomer bead scheme

```
gsdfile = "100-20mers.gsd"
system = cg_gsd.System(gsd_file=gsdfile, gsd_frame=0, atoms_per_monomer=22)

sequence = "PM"
for molecule in system.molecules:
    molecule.assign_types(sequence=sequence)

snap = writers.write_snapshot(beads=[i for i in system.monomers()])
cg_monomers_gsd = gsd.hoomd.open(name="cg_monomers_peek.gsd", mode="wb")
cg_monomers.append(snap)
```

