### PR TITLE
Set mass of CG_Compound and CG_System

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - numpy
   - openbabel
   - pip
+  - pre-commit
   - py3Dmol
   - pytest
   - pytest-cov

--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -615,6 +615,7 @@ class CG_System:
             for s in old[start:stop]:
                 new_snap = gsd.hoomd.Snapshot()
                 position = []
+                mass = []
                 f_box = freud.Box.from_box(s.configuration.box)
                 unwrap_pos = f_box.unwrap(
                     s.particles.position, s.particles.image
@@ -623,7 +624,8 @@ class CG_System:
                 typeid = []
                 for i, inds in enumerate(self.mapping.values()):
                     typeid.append(np.ones(len(inds)) * i)
-                    position += [np.mean(unwrap_pos[i], axis=0) for i in inds]
+                    position += [np.mean(unwrap_pos[x], axis=0) for x in inds]
+                    mass += [sum(s.particles.mass[x]) for x in inds]
 
                 position = np.vstack(position)
                 images = f_box.get_images(position)
@@ -637,6 +639,7 @@ class CG_System:
                 new_snap.particles.image = images
                 new_snap.particles.typeid = typeid
                 new_snap.particles.types = types
+                new_snap.particles.mass = mass
                 if self._bond_array is not None:
                     new_snap.bonds.N = self._bond_array.shape[0]
                     new_snap.bonds.group = self._bond_array

--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -175,9 +175,10 @@ class CG_Compound(Compound):
         for key, inds in self.mapping.items():
             name, smarts = key.split("...")
             for group in inds:
+                mass = sum([self.atomistic[i].mass for i in group])
                 bead_xyz = self.atomistic.xyz[group, :]
                 avg_xyz = np.mean(bead_xyz, axis=0)
-                bead = Bead(name=name, pos=avg_xyz, smarts=smarts)
+                bead = Bead(name=name, pos=avg_xyz, smarts=smarts, mass=mass)
                 self.add(bead)
 
     def _cg_bonds(self):

--- a/grits/tests/test_coarsegrain.py
+++ b/grits/tests/test_coarsegrain.py
@@ -39,7 +39,7 @@ class Test_CGCompound(BaseTest):
         assert "_S" in types
         assert len(types) == 2
         assert np.isclose(cg_p3ht[0].mass, 80.104)
-        assert np.isclose(cg_p3ht[1].mass, 36.033)
+        assert np.isclose(cg_p3ht[17].mass, 36.033)
 
     def test_initp3htoverlap(self, p3ht):
         cg_beads = {"_B": "c1sccc1", "_S": "CCC"}

--- a/grits/tests/test_coarsegrain.py
+++ b/grits/tests/test_coarsegrain.py
@@ -24,6 +24,7 @@ class Test_CGCompound(BaseTest):
         types = set([i.name for i in cg_methane.particles()])
         assert "_A" in types
         assert len(types) == 1
+        assert np.isclose(cg_methane.mass, 12.011)
 
     def test_initp3ht(self, p3ht):
         cg_beads = {"_B": "c1sccc1", "_S": "CCC"}
@@ -37,6 +38,8 @@ class Test_CGCompound(BaseTest):
         assert "_B" in types
         assert "_S" in types
         assert len(types) == 2
+        assert np.isclose(cg_p3ht[0].mass, 80.104)
+        assert np.isclose(cg_p3ht[1].mass, 36.033)
 
     def test_initp3htoverlap(self, p3ht):
         cg_beads = {"_B": "c1sccc1", "_S": "CCC"}
@@ -117,6 +120,10 @@ class Test_CGSystem(BaseTest):
 
         cg_gsd = tmp_path / "cg-p3ht.gsd"
         system.save(cg_gsd)
+        with gsd.hoomd.open(cg_gsd) as f:
+            snap = f[0]
+            assert len(set(snap.particles.mass)) == 2
+            assert np.isclose(snap.particles.mass[0], 2.49844)
 
         cg_json = tmp_path / "cg-p3ht.json"
         system.save_mapping(cg_json)


### PR DESCRIPTION
Fixes #26 

Previously the mass of the CG_Compound and CG_System were not set, this PR changes that such that they are set based on the sum of their atomistic components.

(The units will be the same as the atomistic compound or gsdfile.)