### PR TITLE
Populate `snapshot.bonds.types` and `snapshot.bonds.typeid`

### DIFF
--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -593,7 +593,7 @@ class CG_System:
         Retains:
             - configuration: box, step
             - particles: N, position, typeid, types
-            - bonds: N, group
+            - bonds: N, group, typeid, types
 
         Parameters
         ----------
@@ -607,6 +607,30 @@ class CG_System:
             Where to stop reading the gsd trajectory the system was created
             with. If None, will stop at the last frame.
         """
+        typeid = []
+        types = [i.split("...")[0] for i in self.mapping]
+        for i, inds in enumerate(self.mapping.values()):
+            typeid.append(np.ones(len(inds)) * i)
+        typeid = np.hstack(typeid)
+
+        # Set up bond information if it exists 
+        bond_types = []
+        bond_ids = []
+        N_bonds = 0
+        if self._bond_array is not None:
+            N_bonds = self._bond_array.shape[0]
+            for bond in self._bond_array:
+                bond_pair = "-".join(
+                    [
+                        types[int(typeid[int(bond[0])])],
+                        types[int(typeid[int(bond[1])])],
+                    ]
+                )
+                if bond_pair not in bond_types:
+                    bond_types.append(bond_pair)
+                _id = np.where(np.array(bond_types) == bond_pair)[0]
+                bond_ids.append(_id)
+
         with gsd.hoomd.open(cg_gsdfile, "wb") as new, gsd.hoomd.open(
             self.gsdfile, "rb"
         ) as old:
@@ -620,17 +644,13 @@ class CG_System:
                 unwrap_pos = f_box.unwrap(
                     s.particles.position, s.particles.image
                 )
-                types = [i.split("...")[0] for i in self.mapping]
-                typeid = []
                 for i, inds in enumerate(self.mapping.values()):
-                    typeid.append(np.ones(len(inds)) * i)
                     position += [np.mean(unwrap_pos[x], axis=0) for x in inds]
                     mass += [sum(s.particles.mass[x]) for x in inds]
 
                 position = np.vstack(position)
                 images = f_box.get_images(position)
                 position = f_box.wrap(position)
-                typeid = np.hstack(typeid)
 
                 new_snap.configuration.box = s.configuration.box
                 new_snap.configuration.step = s.configuration.step
@@ -640,24 +660,8 @@ class CG_System:
                 new_snap.particles.typeid = typeid
                 new_snap.particles.types = types
                 new_snap.particles.mass = mass
-
-                if self._bond_array is not None:
-                    new_snap.bonds.N = self._bond_array.shape[0]
-                    bond_types = []
-                    bond_ids = []
-                    for bond in self._bond_array:
-                        bond_pair = "-".join(
-                            [
-                                types[int(typeid[int(bond[0])])],
-                                types[int(typeid[int(bond[1])])],
-                            ]
-                        )
-                        if bond_pair not in bond_types:
-                            bond_types.append(bond_pair)
-                        _id = np.where(np.array(bond_types) == bond_pair)[0]
-                        bond_ids.append(_id)
-
-                    new_snap.bonds.group = self._bond_array
-                    new_snap.bonds.types = np.array(bond_types)
-                    new_snap.bonds.typeid = np.array(bond_ids)
+                new_snap.bonds.N = N_bonds
+                new_snap.bonds.group = self._bond_array
+                new_snap.bonds.types = np.array(bond_types)
+                new_snap.bonds.typeid = np.array(bond_ids)
                 new.append(new_snap)

--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -640,7 +640,20 @@ class CG_System:
                 new_snap.particles.typeid = typeid
                 new_snap.particles.types = types
                 new_snap.particles.mass = mass
+                bonds_types = []
+                bond_ids = []
                 if self._bond_array is not None:
                     new_snap.bonds.N = self._bond_array.shape[0]
+                    for bond in self._bond_array:
+                        bond_pair = "-".join(
+                                types[bond[0]],
+                                types[bond[1]]
+                        )
+                        if bond_pair not in bonds_types:
+                            bond_types.append(bond_pair)
+                        bond_ids.append(np.where(bond_types==bond_pair)[0]) 
+
                     new_snap.bonds.group = self._bond_array
+                    new_snap.bonds.types = np.array(bond_types)
+                    new_snap.bonds.typeid = np.array(bond_ids)
                 new.append(new_snap)

--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -640,18 +640,20 @@ class CG_System:
                 new_snap.particles.typeid = typeid
                 new_snap.particles.types = types
                 new_snap.particles.mass = mass
-                bonds_types = []
-                bond_ids = []
+
                 if self._bond_array is not None:
                     new_snap.bonds.N = self._bond_array.shape[0]
+                    bond_types = []
+                    bond_ids = []
                     for bond in self._bond_array:
-                        bond_pair = "-".join(
-                                types[bond[0]],
-                                types[bond[1]]
-                        )
-                        if bond_pair not in bonds_types:
+                        bond_pair = "-".join([
+                                types[int(typeid[int(bond[0])])],
+                                types[int(typeid[int(bond[1])])]
+                        ])
+                        if bond_pair not in bond_types:
                             bond_types.append(bond_pair)
-                        bond_ids.append(np.where(bond_types==bond_pair)[0]) 
+                        _id = np.where(np.array(bond_types)==bond_pair)[0]
+                        bond_ids.append(_id) 
 
                     new_snap.bonds.group = self._bond_array
                     new_snap.bonds.types = np.array(bond_types)

--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -646,14 +646,16 @@ class CG_System:
                     bond_types = []
                     bond_ids = []
                     for bond in self._bond_array:
-                        bond_pair = "-".join([
+                        bond_pair = "-".join(
+                            [
                                 types[int(typeid[int(bond[0])])],
-                                types[int(typeid[int(bond[1])])]
-                        ])
+                                types[int(typeid[int(bond[1])])],
+                            ]
+                        )
                         if bond_pair not in bond_types:
                             bond_types.append(bond_pair)
-                        _id = np.where(np.array(bond_types)==bond_pair)[0]
-                        bond_ids.append(_id) 
+                        _id = np.where(np.array(bond_types) == bond_pair)[0]
+                        bond_ids.append(_id)
 
                     new_snap.bonds.group = self._bond_array
                     new_snap.bonds.types = np.array(bond_types)

--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -613,7 +613,7 @@ class CG_System:
             typeid.append(np.ones(len(inds)) * i)
         typeid = np.hstack(typeid)
 
-        # Set up bond information if it exists 
+        # Set up bond information if it exists
         bond_types = []
         bond_ids = []
         N_bonds = 0

--- a/grits/tests/test_coarsegrain.py
+++ b/grits/tests/test_coarsegrain.py
@@ -124,7 +124,9 @@ class Test_CGSystem(BaseTest):
             snap = f[0]
             assert len(set(snap.particles.mass)) == 2
             assert np.isclose(snap.particles.mass[0], 2.49844)
-            assert len(snap.bonds.typeid)==len(snap.bonds.group)==snap.bonds.N
+            assert (
+                len(snap.bonds.typeid) == len(snap.bonds.group) == snap.bonds.N
+            )
             assert len(snap.bonds.types) == 3
 
         cg_json = tmp_path / "cg-p3ht.json"

--- a/grits/tests/test_coarsegrain.py
+++ b/grits/tests/test_coarsegrain.py
@@ -125,6 +125,7 @@ class Test_CGSystem(BaseTest):
             assert len(set(snap.particles.mass)) == 2
             assert np.isclose(snap.particles.mass[0], 2.49844)
             assert len(snap.bonds.typeid)==len(snap.bonds.group)==snap.bonds.N
+            assert len(snap.bonds.types) == 3
 
         cg_json = tmp_path / "cg-p3ht.json"
         system.save_mapping(cg_json)

--- a/grits/tests/test_coarsegrain.py
+++ b/grits/tests/test_coarsegrain.py
@@ -124,6 +124,7 @@ class Test_CGSystem(BaseTest):
             snap = f[0]
             assert len(set(snap.particles.mass)) == 2
             assert np.isclose(snap.particles.mass[0], 2.49844)
+            assert len(snap.bonds.typeid)==len(snap.bonds.group)==snap.bonds.N
 
         cg_json = tmp_path / "cg-p3ht.json"
         system.save_mapping(cg_json)


### PR DESCRIPTION
This PR ensures that both `snapshot.bonds.types` and `snapshot.bonds.typeid` are populated. All of the work to identify bonds is pretty much done, this just iterates through the existing information to populate these fields of the snapshot.  

So far it seems to work on a simple system (PEKK) where there are 2 kinds of beads. I sitll need to add unit tests and try it out a system that has some kind of branching (p3ht)

