### PR TITLE
Save angle and dihedrals in CG snapshots

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,3 +18,4 @@ dependencies:
   - pytest
   - pytest-cov
   - rdkit
+  - cmeutils >= 1.2.0

--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -13,6 +13,7 @@ from ele import element_from_symbol
 from mbuild import Compound, clone
 from mbuild.utils.io import run_from_ipython
 from openbabel import pybel
+from cmeutils.gsd_utils import identify_snapshot_connections
 
 from grits.utils import (
     NumpyEncoder,
@@ -760,7 +761,7 @@ class CG_System:
                 new_snap.particles.N = len(typeid)
                 new_snap.particles.position = position
                 new_snap.particles.image = images
-                new_snap.particles.typeid = typeid
+                new_snap.particles.typeid = typeid.astype(int)
                 new_snap.particles.types = types
                 new_snap.particles.mass = mass
 
@@ -775,4 +776,5 @@ class CG_System:
                     new_snap.bonds.type_shapes = bond_type_shapes
                     if self.aniso_beads:
                         new_snap.particles.orientation = orientation
+                    new_snap = identify_snapshot_connections(new_snap)
                 new.append(new_snap)

--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -9,11 +9,11 @@ import ele
 import freud
 import gsd.hoomd
 import numpy as np
+from cmeutils.gsd_utils import identify_snapshot_connections
 from ele import element_from_symbol
 from mbuild import Compound, clone
 from mbuild.utils.io import run_from_ipython
 from openbabel import pybel
-from cmeutils.gsd_utils import identify_snapshot_connections
 
 from grits.utils import (
     NumpyEncoder,

--- a/grits/tests/test_coarsegrain.py
+++ b/grits/tests/test_coarsegrain.py
@@ -274,9 +274,24 @@ class Test_CGSystem(BaseTest):
         with gsd.hoomd.open(cg_gsd) as f:
             snap = f[0]
             assert (
-                len(snap.bonds.typeid) == len(snap.bonds.group) == snap.bonds.N
+                    len(snap.bonds.typeid) == len(
+                snap.bonds.group) == snap.bonds.N
             )
             assert len(snap.bonds.types) == 1
+
+            assert (
+                    len(snap.angles.typeid) == len(
+                snap.angles.group) == snap.angles.N
+            )
+            assert snap.angles.N == 15 * 13
+            assert snap.angles.types == ['_B-_B-_B']
+
+            assert (
+                    len(snap.dihedrals.typeid) == len(
+                snap.dihedrals.group) == snap.dihedrals.N
+            )
+            assert snap.dihedrals.N == 15 * 12
+            assert snap.dihedrals.types == ['_B-_B-_B-_B']
 
         cg_json = tmp_path / "cg-pps.json"
         system.save_mapping(cg_json)
@@ -300,9 +315,23 @@ class Test_CGSystem(BaseTest):
         with gsd.hoomd.open(cg_gsd) as f:
             snap = f[0]
             assert (
-                len(snap.bonds.typeid) == len(snap.bonds.group) == snap.bonds.N
+                    len(snap.bonds.typeid) == len(
+                snap.bonds.group) == snap.bonds.N
             )
             assert len(snap.bonds.types) == 1
+            assert (
+                    len(snap.angles.typeid) == len(
+                snap.angles.group) == snap.angles.N
+            )
+            assert snap.angles.N == 15 * 13
+            assert snap.angles.types == ['_B-_B-_B']
+
+            assert (
+                    len(snap.dihedrals.typeid) == len(
+                snap.dihedrals.group) == snap.dihedrals.N
+            )
+            assert snap.dihedrals.N == 15 * 12
+            assert snap.dihedrals.types == ['_B-_B-_B-_B']
 
         cg_json = tmp_path / "cg-pps.json"
         system.save_mapping(cg_json)

--- a/grits/tests/test_coarsegrain.py
+++ b/grits/tests/test_coarsegrain.py
@@ -274,24 +274,25 @@ class Test_CGSystem(BaseTest):
         with gsd.hoomd.open(cg_gsd) as f:
             snap = f[0]
             assert (
-                    len(snap.bonds.typeid) == len(
-                snap.bonds.group) == snap.bonds.N
+                len(snap.bonds.typeid) == len(snap.bonds.group) == snap.bonds.N
             )
             assert len(snap.bonds.types) == 1
 
             assert (
-                    len(snap.angles.typeid) == len(
-                snap.angles.group) == snap.angles.N
+                len(snap.angles.typeid)
+                == len(snap.angles.group)
+                == snap.angles.N
             )
             assert snap.angles.N == 15 * 13
-            assert snap.angles.types == ['_B-_B-_B']
+            assert snap.angles.types == ["_B-_B-_B"]
 
             assert (
-                    len(snap.dihedrals.typeid) == len(
-                snap.dihedrals.group) == snap.dihedrals.N
+                len(snap.dihedrals.typeid)
+                == len(snap.dihedrals.group)
+                == snap.dihedrals.N
             )
             assert snap.dihedrals.N == 15 * 12
-            assert snap.dihedrals.types == ['_B-_B-_B-_B']
+            assert snap.dihedrals.types == ["_B-_B-_B-_B"]
 
         cg_json = tmp_path / "cg-pps.json"
         system.save_mapping(cg_json)
@@ -315,23 +316,24 @@ class Test_CGSystem(BaseTest):
         with gsd.hoomd.open(cg_gsd) as f:
             snap = f[0]
             assert (
-                    len(snap.bonds.typeid) == len(
-                snap.bonds.group) == snap.bonds.N
+                len(snap.bonds.typeid) == len(snap.bonds.group) == snap.bonds.N
             )
             assert len(snap.bonds.types) == 1
             assert (
-                    len(snap.angles.typeid) == len(
-                snap.angles.group) == snap.angles.N
+                len(snap.angles.typeid)
+                == len(snap.angles.group)
+                == snap.angles.N
             )
             assert snap.angles.N == 15 * 13
-            assert snap.angles.types == ['_B-_B-_B']
+            assert snap.angles.types == ["_B-_B-_B"]
 
             assert (
-                    len(snap.dihedrals.typeid) == len(
-                snap.dihedrals.group) == snap.dihedrals.N
+                len(snap.dihedrals.typeid)
+                == len(snap.dihedrals.group)
+                == snap.dihedrals.N
             )
             assert snap.dihedrals.N == 15 * 12
-            assert snap.dihedrals.types == ['_B-_B-_B-_B']
+            assert snap.dihedrals.types == ["_B-_B-_B-_B"]
 
         cg_json = tmp_path / "cg-pps.json"
         system.save_mapping(cg_json)


### PR DESCRIPTION
This PR uses the new cmeutils function `identify_snapshot_connections` to identify the angle and dihedral connections from the bonds in a CG snapshot.