### PR TITLE
Fix parameter name passed in `visualize` for showing ports

### DIFF
--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -362,7 +362,7 @@ class CG_Compound(Compound):
         if atom_names:
             atomistic.save(
                 os.path.join(tmp_dir, "atomistic_tmp.mol2"),
-                show_ports=show_ports,
+                include_ports=show_ports,
                 overwrite=True,
             )
 
@@ -397,7 +397,7 @@ class CG_Compound(Compound):
                 simplefilter("ignore")
                 coarse.save(
                     os.path.join(tmp_dir, "coarse_tmp.mol2"),
-                    show_ports=show_ports,
+                    include_ports=show_ports,
                     overwrite=True,
                 )
             with open(os.path.join(tmp_dir, "coarse_tmp.mol2"), "r") as f:


### PR DESCRIPTION
It looks like parmed changed one of their parameter names from `show_ports` to `include_ports`. This PR fixes this. We keep the `show_ports` parameter name in GRiTS (same as mbuild), but this changes the parameter used when calling `.save`