### PR TITLE
Update to freud 3.0, use `get_molecule_cluster` from cmeutils

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,14 +2,13 @@ name: grits
 channels:
   - conda-forge
 dependencies:
-  - cmeutils >= 1.2.0
+  - cmeutils >=1.2.0
   - ele
-  - freud = 2.13.2
-  - gsd >= 3.0
+  - freud >=3.0
+  - gsd >=3.0
   - jupyterlab
-  - mbuild
+  - mbuild >=0.17.1
   - ele
-  - freud
   - numpy
   - openbabel
   - pip
@@ -17,4 +16,4 @@ dependencies:
   - py3Dmol
   - pytest
   - pytest-cov
-  - python = 3.10
+  - python >=3.10

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: grits
 channels:
   - conda-forge
 dependencies:
-  - cmeutils >=1.2.0
+  - cmeutils >=1.3.0
   - ele
   - freud >=3.0
   - gsd >=3.0

--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -10,7 +10,7 @@ import ele
 import freud
 import gsd.hoomd
 import numpy as np
-from cmeutils.gsd_utils import identify_snapshot_connections
+from cmeutils.gsd_utils import get_molecule_cluster, identify_snapshot_connections
 from ele import element_from_symbol
 from mbuild import Compound, clone
 from mbuild.utils.io import run_from_ipython
@@ -24,7 +24,6 @@ from grits.utils import (
     get_quaternion,
     has_common_member,
     has_number,
-    snap_molecules,
 )
 
 __all__ = ["CG_Compound", "CG_System", "Bead"]
@@ -574,7 +573,7 @@ class CG_System:
                 conversion_dict[i].symbol for i in snap.particles.types
             ]
         # Break apart the snapshot into separate molecules
-        molecules = snap_molecules(snap)
+        molecules = get_molecule_cluster(snap=snap)
         mol_inds = []
         for i in range(max(molecules) + 1):
             mol_inds.append(np.where(molecules == i)[0])

--- a/grits/utils.py
+++ b/grits/utils.py
@@ -82,23 +82,6 @@ def comp_from_snapshot(snapshot, indices, length_scale=1.0, mass_scale=1.0):
     return comp
 
 
-def snap_molecules(snap):
-    """Get the molecule indices based on bonding in a gsd.hoomd.Frame."""
-    system = freud.AABBQuery.from_system(snap)
-    n_query_points = n_points = snap.particles.N
-    query_point_indices = snap.bonds.group[:, 0]
-    point_indices = snap.bonds.group[:, 1]
-    distances = system.box.compute_distances(
-        system.points[query_point_indices], system.points[point_indices]
-    )
-    nlist = freud.NeighborList.from_arrays(
-        n_query_points, n_points, query_point_indices, point_indices, distances
-    )
-    cluster = freud.cluster.Cluster()
-    cluster.compute(system=system, neighbors=nlist)
-    return cluster.cluster_idx
-
-
 def align(compound, particle, towards_compound, around=None):
     """Spin a compound such that particle points at towards_compound.
 


### PR DESCRIPTION
We have 2 versions of this `get_molecule_cluster` method floating around, one here and one in cmeutils. For the sake of making things easier to manage (updating to freud 3.0), I'm removing it from here and importing it from cmeutils.