### PR TITLE
Remove unnecessary conversions to numpy arrays (fixes gsd writer issue), remove `self.atomistic` from `__repr__` method.

### DIFF
--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -139,7 +139,6 @@ class CG_Compound(Compound):
         """Format the CG_Compound representation."""
         return (
             f"<{self.name}: {self.n_particles} beads "
-            + f"(from {self.atomistic.n_particles} atoms), "
             + "pos=({:.4f},{: .4f},{: .4f}), ".format(*self.pos)
             + f"{self.n_bonds:d} bonds>"
         )

--- a/grits/coarsegrain.py
+++ b/grits/coarsegrain.py
@@ -718,7 +718,7 @@ class CG_System:
                 )
                 if bond_pair not in bond_types:
                     bond_types.append(bond_pair)
-                _id = np.where(np.array(bond_types) == bond_pair)[0]
+                _id = bond_types.index(bond_pair)
                 bond_ids.append(_id)
         else:
             bond_types = None
@@ -776,9 +776,9 @@ class CG_System:
                 if N_bonds > 0:
                     new_snap.bonds.N = N_bonds
                     new_snap.bonds.group = self._bond_array
-                    new_snap.bonds.typeid = np.array(bond_ids)
+                    new_snap.bonds.typeid = bond_ids
                     if bond_types is not None:
-                        new_snap.bonds.types = np.array(bond_types)
+                        new_snap.bonds.types = bond_types
                     else:
                         new_snap.bonds.types = None
                     new_snap.bonds.type_shapes = bond_type_shapes


### PR DESCRIPTION
I've been running into a couple issues.

1) gsd.hoomd errors out during a validation step before writing a new snapshot to file. This is caused by converting the `bond_types` list to an array before appending the snapshot to the new gsd file.

In `gsd.hoomd`
```
        if name == 'types':
            matches_default_value = data == container._default_value[name]
```

`container._decult_value[name]` is an empty list for bonds/angles/dihedrals, and `data` (passed in by grits) was an array of strings, resulting in numpy-related broadcast error.

A quick example here:

```
>>> myarr = np.array(["A", "B"])
>>> myarr == []
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: operands could not be broadcast together with shapes (2,) (0,)
>>> mylist = ["A", "B"]
>>> mylist == []
False
>>>
```

2) `self.atomistic` is throwing an error only when calling the `visualize()` method. I'm fairly certain this is caused by cloning of the compound which we've added some custom attributes to. I think it's fine to remove this bit of information from the `__repr__` method only, the attribute itself is still there, and works when called directly.